### PR TITLE
Allow use of DiscreteUniform distribution for CategoricalGibbsMetropolis step method. #3419

### DIFF
--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -400,9 +400,14 @@ class CategoricalGibbsMetropolis(ArrayStep):
                 k = draw_values([distr.k])[0]
             elif isinstance(distr, pm.Bernoulli) or (v.dtype in pm.bool_types):
                 k = 2
+            elif isinstance(distr, pm.DiscreteUniform):
+                k = draw_values([distr.upper])[0]
+                if draw_values([distr.lower])[0] != 0:
+                    raise ValueError('Parameter lower must be 0 to use DiscreteUniform' +
+                                     'with CategoricalGibbsMetropolis.')
             else:
-                raise ValueError('All variables must be categorical or binary' +
-                                 'for CategoricalGibbsMetropolis')
+                raise ValueError('All variables must be categorical, binary' +
+                                 'or DiscreteUniform for CategoricalGibbsMetropolis')
             start = len(dimcats)
             dimcats += [(dim, k) for dim in range(start, start + v.dsize)]
 
@@ -478,8 +483,8 @@ class CategoricalGibbsMetropolis(ArrayStep):
     @staticmethod
     def competence(var):
         '''
-        CategoricalGibbsMetropolis is only suitable for Bernoulli and
-        Categorical variables.
+        CategoricalGibbsMetropolis is only suitable for Bernoulli, 
+        Categorical and DiscreteUniform variables.
         '''
         distribution = getattr(
             var.distribution, 'parent_dist', var.distribution)
@@ -488,6 +493,8 @@ class CategoricalGibbsMetropolis(ArrayStep):
                 return Competence.IDEAL
             return Competence.COMPATIBLE
         elif isinstance(distribution, pm.Bernoulli) or (var.dtype in pm.bool_types):
+            return Competence.COMPATIBLE
+        elif isinstance(distribution, pm.DiscreteUniform) and draw_values([distribution.lower])[0] == 0:
             return Competence.COMPATIBLE
         return Competence.INCOMPATIBLE
 


### PR DESCRIPTION
The CategoricalGibbsMetropolis step method is the default for the Categorical distribution. The Metropolis step method may not work for Categorical in some circumstances, e,.g. as part of compound distribution. However, CategoricalGibbsMetropolis currently can only be used with Categorical or Bernoulli distributions.

For some models it is necessary to use a DiscreteUniform distribution rather than Categorical, as the k parameter can be very large. This change allows the CategoricalGibbsMetropolis step method to be used for DiscreteUniform distributions. The parameter `lower' is required to be zero.